### PR TITLE
Support external configuration of HTTP-related timeouts when invoking microservice endpoints.

### DIFF
--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/RequestConfigConfigurer.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/RequestConfigConfigurer.java
@@ -53,9 +53,9 @@ public class RequestConfigConfigurer implements HttpClientConfigurer {
      * @see #setSocketTimeoutMs(int)
      */
     @Override
-    public void configureHttpClient(HttpClientBuilder clientBuilder) {
-        RequestConfig.Builder builder = RequestConfig.copy(RequestConfig.DEFAULT);
-        RequestConfig config = buildConfig(builder);
+    public void configureHttpClient(final HttpClientBuilder clientBuilder) {
+        final RequestConfig.Builder builder = RequestConfig.copy(RequestConfig.DEFAULT);
+        final RequestConfig config = buildConfig(builder);
         clientBuilder.setDefaultRequestConfig(config);
     }
 
@@ -65,7 +65,7 @@ public class RequestConfigConfigurer implements HttpClientConfigurer {
      * @param builder the RequestConfig builder
      * @return the RequestConfig
      */
-    RequestConfig buildConfig(RequestConfig.Builder builder) {
+    RequestConfig buildConfig(final RequestConfig.Builder builder) {
         builder.setConnectionRequestTimeout(connectionRequestTimeoutMs)
                 .setSocketTimeout(socketTimeoutMs)
                 .setConnectTimeout(connectTimeoutMs);
@@ -73,27 +73,57 @@ public class RequestConfigConfigurer implements HttpClientConfigurer {
         return built;
     }
 
+    /**
+     * Get the value of the connection request timeout
+     *
+     * @return the value
+     */
     public int getConnectionRequestTimeoutMs() {
         return connectionRequestTimeoutMs;
     }
 
-    public void setConnectionRequestTimeoutMs(int connectionRequestTimeoutMs) {
+    /**
+     * Set the value of the connection request timeout
+     *
+     * @param connectionRequestTimeoutMs the value
+     */
+    public void setConnectionRequestTimeoutMs(final int connectionRequestTimeoutMs) {
         this.connectionRequestTimeoutMs = connectionRequestTimeoutMs;
     }
 
+    /**
+     * Get the value of the connect timeout
+     *
+     * @return the value
+     */
     public int getConnectTimeoutMs() {
         return connectTimeoutMs;
     }
 
-    public void setConnectTimeoutMs(int connectTimeoutMs) {
+    /**
+     * Set the value of the connect timeout
+     *
+     * @param connectTimeoutMs the value
+     */
+    public void setConnectTimeoutMs(final int connectTimeoutMs) {
         this.connectTimeoutMs = connectTimeoutMs;
     }
 
+    /**
+     * Get the value of the socket timeout
+     *
+     * @return the value
+     */
     public int getSocketTimeoutMs() {
         return socketTimeoutMs;
     }
 
-    public void setSocketTimeoutMs(int socketTimeoutMs) {
+    /**
+     * Set the value of the socket timeout
+     *
+     * @param socketTimeoutMs the value
+     */
+    public void setSocketTimeoutMs(final int socketTimeoutMs) {
         this.socketTimeoutMs = socketTimeoutMs;
     }
 }

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/RequestConfigConfigurer.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/RequestConfigConfigurer.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Islandora Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Islandora Foundation licenses this file to you under the MIT License.
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.islandora.alpaca.connector.derivative;
+
+import org.apache.camel.component.http4.HttpClientConfigurer;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+/**
+ * Provides a default HttpClient {@link RequestConfig} with custom values for connection request, connect, and socket
+ * timeout values.  Custom values must be set on this class prior to invoking
+ * {@link #configureHttpClient(HttpClientBuilder)}.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class RequestConfigConfigurer implements HttpClientConfigurer {
+
+    /**
+     * The RequestConfig instance that is built by this configurer; exposed for testing purposes.
+     */
+    RequestConfig built;
+
+    private int connectionRequestTimeoutMs = RequestConfig.DEFAULT.getConnectionRequestTimeout();
+
+    private int connectTimeoutMs = RequestConfig.DEFAULT.getConnectTimeout();
+
+    private int socketTimeoutMs = RequestConfig.DEFAULT.getSocketTimeout();
+
+    /**
+     * Creates a {@link RequestConfig} using custom values for {@code connectionRequestTimeout}, {@code connectTimeout},
+     * and {@code socketTimeout}.  If custom values are not provided by this class, then the default values from
+     * {@link RequestConfig#DEFAULT} are used.
+     *
+     * @param clientBuilder the HttpClientBuilder
+     * @see #setConnectionRequestTimeoutMs(int)
+     * @see #setConnectTimeoutMs(int)
+     * @see #setSocketTimeoutMs(int)
+     */
+    @Override
+    public void configureHttpClient(HttpClientBuilder clientBuilder) {
+        RequestConfig.Builder builder = RequestConfig.copy(RequestConfig.DEFAULT);
+        RequestConfig config = buildConfig(builder);
+        clientBuilder.setDefaultRequestConfig(config);
+    }
+
+    /**
+     * Package-private to support testing.
+     *
+     * @param builder the RequestConfig builder
+     * @return the RequestConfig
+     */
+    RequestConfig buildConfig(RequestConfig.Builder builder) {
+        builder.setConnectionRequestTimeout(connectionRequestTimeoutMs)
+                .setSocketTimeout(socketTimeoutMs)
+                .setConnectTimeout(connectTimeoutMs);
+        built = builder.build();
+        return built;
+    }
+
+    public int getConnectionRequestTimeoutMs() {
+        return connectionRequestTimeoutMs;
+    }
+
+    public void setConnectionRequestTimeoutMs(int connectionRequestTimeoutMs) {
+        this.connectionRequestTimeoutMs = connectionRequestTimeoutMs;
+    }
+
+    public int getConnectTimeoutMs() {
+        return connectTimeoutMs;
+    }
+
+    public void setConnectTimeoutMs(int connectTimeoutMs) {
+        this.connectTimeoutMs = connectTimeoutMs;
+    }
+
+    public int getSocketTimeoutMs() {
+        return socketTimeoutMs;
+    }
+
+    public void setSocketTimeoutMs(int socketTimeoutMs) {
+        this.socketTimeoutMs = socketTimeoutMs;
+    }
+}

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/HttpConfigurerTest.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/HttpConfigurerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Islandora Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Islandora Foundation licenses this file to you under the MIT License.
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.islandora.alpaca.connector.derivative;
+
+import org.apache.camel.component.http4.HttpComponent;
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.junit.Test;
+
+/**
+ * Insures that the Camel HTTP component as configured by Blueprint is properly configured.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class HttpConfigurerTest extends CamelBlueprintTestSupport {
+
+    @Override
+    protected String getBlueprintDescriptor() {
+        return "/OSGI-INF/blueprint/blueprint-httpconfigurer-test.xml";
+    }
+
+    /**
+     * Insure that the default RequestConfig for the HttpComponent carries the timeout values specified in the
+     * blueprint xml.
+     *
+     * Note that the RequestConfig and RequestConfigConfigurer are difficult to test with mocking frameworks such as
+     * Mockito due to the presence of final methods in the relevant HttpClient classes.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRequestConfig() throws Exception {
+        context.start();
+        HttpComponent http = (HttpComponent) context.getComponent("http");
+
+        RequestConfigConfigurer configurer = (RequestConfigConfigurer) http.getHttpClientConfigurer();
+
+        assertEquals(10000, configurer.built.getSocketTimeout());
+        assertEquals(10000, configurer.built.getConnectTimeout());
+        assertEquals(10000, configurer.built.getConnectionRequestTimeout());
+    }
+
+}

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/HttpConfigurerTest.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/HttpConfigurerTest.java
@@ -46,9 +46,9 @@ public class HttpConfigurerTest extends CamelBlueprintTestSupport {
     @Test
     public void testRequestConfig() throws Exception {
         context.start();
-        HttpComponent http = (HttpComponent) context.getComponent("http");
+        final HttpComponent http = (HttpComponent) context.getComponent("http");
 
-        RequestConfigConfigurer configurer = (RequestConfigConfigurer) http.getHttpClientConfigurer();
+        final RequestConfigConfigurer configurer = (RequestConfigConfigurer) http.getHttpClientConfigurer();
 
         assertEquals(10000, configurer.built.getSocketTimeout());
         assertEquals(10000, configurer.built.getConnectTimeout());

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/RequestConfigConfigurerTest.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/RequestConfigConfigurerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Islandora Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Islandora Foundation licenses this file to you under the MIT License.
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.islandora.alpaca.connector.derivative;
+
+import org.apache.http.client.config.RequestConfig;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Verifies the behaviors and state of the RequestConfigConfigurer.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class RequestConfigConfigurerTest {
+
+    /**
+     * The default state of the RequestConfigConfigurer should provide the same timeout values as the default
+     * RequestConfig.
+     */
+    @Test
+    public void testDefaultValues() {
+        RequestConfigConfigurer underTest = new RequestConfigConfigurer();
+
+        assertEquals(RequestConfig.DEFAULT.getConnectionRequestTimeout(), underTest.getConnectionRequestTimeoutMs());
+        assertEquals(RequestConfig.DEFAULT.getConnectTimeout(), underTest.getConnectTimeoutMs());
+        assertEquals(RequestConfig.DEFAULT.getSocketTimeout(), underTest.getSocketTimeoutMs());
+    }
+
+    /**
+     * Insure state is properly maintained by the RequestConfigConfigurer.
+     */
+    @Test
+    public void testCustomValues() {
+        RequestConfigConfigurer underTest = new RequestConfigConfigurer();
+        underTest.setConnectionRequestTimeoutMs(12345);
+        underTest.setConnectTimeoutMs(1111111);
+        underTest.setSocketTimeoutMs(9999999);
+
+        assertEquals(12345, underTest.getConnectionRequestTimeoutMs());
+        assertEquals(1111111, underTest.getConnectTimeoutMs());
+        assertEquals(9999999, underTest.getSocketTimeoutMs());
+    }
+
+    /**
+     * Insure state from the RequestConfigConfigurer is properly communicated to the built RequestConfig.
+     */
+    @Test
+    public void testBuild() {
+        RequestConfigConfigurer underTest = new RequestConfigConfigurer();
+        underTest.setConnectionRequestTimeoutMs(12345);
+        underTest.setConnectTimeoutMs(1111111);
+        underTest.setSocketTimeoutMs(9999999);
+
+        underTest.buildConfig(RequestConfig.custom());
+
+        assertNotNull(underTest.built);
+
+        assertEquals(12345, underTest.built.getConnectionRequestTimeout());
+        assertEquals(1111111, underTest.built.getConnectTimeout());
+        assertEquals(9999999, underTest.built.getSocketTimeout());
+    }
+}

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/RequestConfigConfigurerTest.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/RequestConfigConfigurerTest.java
@@ -37,7 +37,7 @@ public class RequestConfigConfigurerTest {
      */
     @Test
     public void testDefaultValues() {
-        RequestConfigConfigurer underTest = new RequestConfigConfigurer();
+        final RequestConfigConfigurer underTest = new RequestConfigConfigurer();
 
         assertEquals(RequestConfig.DEFAULT.getConnectionRequestTimeout(), underTest.getConnectionRequestTimeoutMs());
         assertEquals(RequestConfig.DEFAULT.getConnectTimeout(), underTest.getConnectTimeoutMs());
@@ -49,7 +49,7 @@ public class RequestConfigConfigurerTest {
      */
     @Test
     public void testCustomValues() {
-        RequestConfigConfigurer underTest = new RequestConfigConfigurer();
+        final RequestConfigConfigurer underTest = new RequestConfigConfigurer();
         underTest.setConnectionRequestTimeoutMs(12345);
         underTest.setConnectTimeoutMs(1111111);
         underTest.setSocketTimeoutMs(9999999);
@@ -64,7 +64,7 @@ public class RequestConfigConfigurerTest {
      */
     @Test
     public void testBuild() {
-        RequestConfigConfigurer underTest = new RequestConfigConfigurer();
+        final RequestConfigConfigurer underTest = new RequestConfigConfigurer();
         underTest.setConnectionRequestTimeoutMs(12345);
         underTest.setConnectTimeoutMs(1111111);
         underTest.setSocketTimeoutMs(9999999);

--- a/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-httpconfigurer-test.xml
+++ b/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-httpconfigurer-test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+       xsi:schemaLocation="
+       http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+       http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+  <!-- OSGI blueprint property placeholder -->
+  <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.derivative" update-strategy="reload" >
+    <cm:default-properties>
+      <cm:property name="error.maxRedeliveries" value="5"/>
+      <cm:property name="in.stream" value="seda:islandora-connector.derivative-index"/>
+      <cm:property name="derivative.service.url" value="http://example.org/derivative/convert"/>
+    </cm:default-properties>
+  </cm:property-placeholder>
+
+  <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
+    <property name="connectionRequestTimeoutMs" value="10000"/>
+    <property name="connectTimeoutMs" value="10000"/>
+    <property name="socketTimeoutMs" value="10000"/>
+  </bean>
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
+
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
+
+  <camelContext id="IslandoraTriplestoreIndexer" xmlns="http://camel.apache.org/schema/blueprint">
+    <package>ca.islandora.alpaca.connector.derivative</package>
+  </camelContext>
+
+</blueprint>


### PR DESCRIPTION
# What does this Pull Request do?

At Johns Hopkins we've found that derivative generation, especially for TIFFs and video files exceeding 500MiB, can exceed the default timeouts of various components in the Islandora stack including: Nginx, PHP-FPM, and Apache HttpClient.  Configuring the timeouts of Nginx and PHP-FPM are relatively easy, but unfortunately Alpaca is slightly more challenging.

There are two options that were explored:
* Add additional parameters to the Camel route URIs to configure timeouts
* Wire in a custom `HttpClientConfigurer` to configure timeouts

The former option would be considered a breaking change: the Alpaca upgrade would not be a drop-in replacement; adopters would need to update their blueprint configurations to supply default values. (AFAICT, the [simple EL](https://camel.apache.org/components/latest/languages/simple-language.html) doesn't provide a way in-line default values).

The latter approach is drop-in.  If adopters do not update their blueprint configuration, then the custom `HttpClientConfigurer` is simply unused. (Note that `DerivativeConnectorTest` passes without any modifications to it or the blueprint).

# What's new?

This PR introduces a custom `HttpClientConfigurer` (`RequestConfigConfigurer`) which is used by Camel to create a default instances of `RequestConfig`, which carries the timeout values described above.

For the Islandora stack, this means updating the Karaf artifacts by amending `blueprint.xml` to add reasonable default values, and optionally supporting custom values using Karaf `cfg` files.  For example, [ISLE users will need to apply](https://github.com/Islandora-Devops/isle-buildkit/tree/main/alpaca/rootfs/etc/confd/templates) something like the following:
```diff
--- /Users/esm/workspaces/idc/Alpaca/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml	2021-06-07 14:02:50.000000000 -0400
+++ /Users/esm/workspaces/idc/Alpaca/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-httpconfigurer-test.xml	2021-06-07 15:56:54.000000000 -0400
@@ -16,8 +16,19 @@
     </cm:default-properties>
   </cm:property-placeholder>
 
-  <bean id="http" class="org.apache.camel.component.http4.HttpComponent"/>
-  <bean id="https" class="org.apache.camel.component.http4.HttpComponent"/>
+  <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
+    <property name="connectionRequestTimeoutMs" value="10000"/>
+    <property name="connectTimeoutMs" value="10000"/>
+    <property name="socketTimeoutMs" value="10000"/>
+  </bean>
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
+
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
 
   <camelContext id="IslandoraTriplestoreIndexer" xmlns="http://camel.apache.org/schema/blueprint">
     <package>ca.islandora.alpaca.connector.derivative</package>
```

> Note that ISLE would probably prefer to obtain these values from the environment.  How these values are set depends on the runtime environment and use of, e.g. `confd`, and are considered out of scope for this PR.

# How should this be tested?

Run tests and see that they pass.  A full end-to-end test (e.g. ingesting a large video file into Islandora and witnessing a service derivative being generated by homarus) may be possible depending on available resources and the alignment of HTTP-related timeouts throughout the stack.