### PR TITLE
Retry failed HTTP operations with an exponential backoff

### DIFF
--- a/islandora-connector-derivative/build.gradle
+++ b/islandora-connector-derivative/build.gradle
@@ -31,6 +31,13 @@ jar {
     }
 }
 
+artifacts {
+    archives (file('build/cfg/main/ca.islandora.alpaca.connector.derivative.cfg')) {
+        classifier 'configuration'
+        type 'cfg'
+    }
+}
+
 test {
     testLogging {
         // Uncomment the below line while debugging.

--- a/islandora-connector-derivative/src/main/cfg/ca.islandora.alpaca.connector.derivative.cfg
+++ b/islandora-connector-derivative/src/main/cfg/ca.islandora.alpaca.connector.derivative.cfg
@@ -2,3 +2,5 @@
 error.maxRedeliveries=10
 # Default redelivery delay
 error.redeliveryDelay=1000
+# Backoff multiplier
+error.backoff=1.2

--- a/islandora-connector-derivative/src/main/cfg/ca.islandora.alpaca.connector.derivative.cfg
+++ b/islandora-connector-derivative/src/main/cfg/ca.islandora.alpaca.connector.derivative.cfg
@@ -1,0 +1,4 @@
+# Number of times to retry
+error.maxRedeliveries=10
+# Default redelivery delay
+error.redeliveryDelay=1000

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -56,7 +56,8 @@ public class DerivativeConnector extends RouteBuilder {
                 .log(
                         WARN,
                         LOGGER,
-                        "Error generating derivative with {{derivative.service.url}}: ${exception.message}\n\n${exception.stacktrace}"
+                        "Error generating derivative with {{derivative.service.url}}: ${exception.message}" +
+                                "\n\n${exception.stacktrace}"
                 );
 
         // Global exception handler for the indexer.
@@ -95,7 +96,10 @@ public class DerivativeConnector extends RouteBuilder {
             .setHeader("Content-Location", simple("${exchangeProperty.event.attachment.content.fileUploadUri}"))
             .setHeader(Exchange.HTTP_METHOD, constant("PUT"))
 
-            .log(DEBUG, LOGGER, "Processing response - Service URL: '{{derivative.service.url}}' Source URI: '${exchangeProperty.event.attachment.content.sourceUri}' File Upload URI: '${exchangeProperty.event.attachment.content.fileUploadUri}' Destination URI: '${exchangeProperty.event.attachment.content.destinationUri}'")
+            .log(DEBUG, LOGGER, "Processing response - Service URL: '{{derivative.service.url}}' " +
+                    "Source URI: '${exchangeProperty.event.attachment.content.sourceUri}' File Upload URI: " +
+                    "'${exchangeProperty.event.attachment.content.fileUploadUri}' Destination URI: " +
+                    "'${exchangeProperty.event.attachment.content.destinationUri}'")
 
             .toD("${exchangeProperty.event.attachment.content.destinationUri}?connectionClose=true");
     }

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -47,7 +47,7 @@ public class DerivativeConnector extends RouteBuilder {
         onException(HttpOperationFailedException.class)
                 .maximumRedeliveries("{{error.maxRedeliveries}}")
                 .redeliveryDelay("{{error.redeliveryDelay}}")
-                .backOffMultiplier(1.2)
+                .backOffMultiplier("{{error.backoff}}")
                 .useExponentialBackOff()
                 .logRetryAttempted(true)
                 .retryAttemptedLogLevel(WARN)

--- a/islandora-connector-derivative/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/islandora-connector-derivative/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,6 +12,7 @@
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="10"/>
       <cm:property name="error.redeliveryDelay" value="1000"/>
+      <cm:property name="error.backoff" value="1.2"/>
       <cm:property name="in.stream" value="broker:queue:islandora-connector-houdini"/>
       <cm:property name="derivative.service.url" value="http://houdini:8000/convert"/>
     </cm:default-properties>

--- a/islandora-connector-derivative/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/islandora-connector-derivative/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,17 +10,19 @@
   <!-- OSGI blueprint property placeholder -->
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.derivative" update-strategy="reload" >
     <cm:default-properties>
-      <cm:property name="error.maxRedeliveries" value="5"/>
+      <cm:property name="error.maxRedeliveries" value="10"/>
       <cm:property name="error.redeliveryDelay" value="1000"/>
-      <cm:property name="in.stream" value="seda:islandora-connector.derivative-index"/>
-      <cm:property name="derivative.service.url" value="http://example.org/derivative/convert"/>
+      <cm:property name="in.stream" value="broker:queue:islandora-connector-houdini"/>
+      <cm:property name="derivative.service.url" value="http://houdini:8000/convert"/>
     </cm:default-properties>
   </cm:property-placeholder>
+
+  <reference id="broker" interface="org.apache.camel.Component" filter="(osgi.jndi.service.name=fcrepo/Broker)"/>
 
   <bean id="http" class="org.apache.camel.component.http4.HttpComponent"/>
   <bean id="https" class="org.apache.camel.component.http4.HttpComponent"/>
 
-  <camelContext id="IslandoraConnectorDerivative" xmlns="http://camel.apache.org/schema/blueprint">
+  <camelContext id="IslandoraConnectorHoudini" xmlns="http://camel.apache.org/schema/blueprint">
     <package>ca.islandora.alpaca.connector.derivative</package>
   </camelContext>
 

--- a/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
+++ b/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
@@ -12,6 +12,7 @@
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="5"/>
       <cm:property name="error.redeliveryDelay" value="1000"/>
+      <cm:property name="error.backoff" value="1.2"/>
       <cm:property name="in.stream" value="seda:islandora-connector.derivative-index"/>
       <cm:property name="derivative.service.url" value="http://example.org/derivative/convert"/>
     </cm:default-properties>

--- a/karaf/src/main/resources/features.xml
+++ b/karaf/src/main/resources/features.xml
@@ -49,6 +49,9 @@
     <bundle dependency="true">mvn:ca.islandora.alpaca/islandora-event-support/${project.version}</bundle>
 
     <bundle>mvn:ca.islandora.alpaca/islandora-connector-derivative/${project.version}</bundle>
+
+    <configfile finalname="/etc/ca.islandora.alpaca.connector.derivative.cfg">mvn:ca.islandora.alpaca/islandora-connector-derivative/${project.version}/cfg/configuration</configfile>
+
   </feature>
 
 </features>


### PR DESCRIPTION
Updates the Islandora DerivativeConnector to retry failed HTTP operations with an exponential backoff, rather than a linear retry.
* Adds a `error.redeliveryDelay` property: governs the initial retry time in milliseconds
* Adds a `error.backoff` property: a multiplier applied to the previous value value of `error.redeliveryDelay`
* Adds `ca.islandora.alpaca.connector.derivative.cfg` with these properties to the bundle.
* Also adds some additional logging statements at `DEBUG` level.

For example, if `error.redeliveryDelay` is 1000ms, and `error.backoff` is `1.2`, the first retry will occur after 1000ms, the second after (1000 * 1.2), the third after (1000 * 1.2 * 1.2), the fourth after (1000 * 1.2 * 1.2 * 1.2), and so on.  This error handling only applies to failed HTTP operations (like a timeout).

