### PR TITLE
Alpaca DLQ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ subprojects {
     checkstyle {
         configFile = rootProject.file('gradle/checkstyle/checkstyle.xml')
         configProperties.checkstyleConfigDir = rootProject.file('gradle/checkstyle')
-        ignoreFailures false
+        ignoreFailures true
     }
 
     license {

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ subprojects {
     checkstyle {
         configFile = rootProject.file('gradle/checkstyle/checkstyle.xml')
         configProperties.checkstyleConfigDir = rootProject.file('gradle/checkstyle')
-        ignoreFailures true
+        ignoreFailures false
     }
 
     license {

--- a/islandora-connector-derivative/src/main/cfg/ca.islandora.alpaca.connector.derivative.cfg
+++ b/islandora-connector-derivative/src/main/cfg/ca.islandora.alpaca.connector.derivative.cfg
@@ -4,3 +4,5 @@ error.maxRedeliveries=10
 error.redeliveryDelay=1000
 # Backoff multiplier
 error.backoff=1.2
+# Dead Letter Queue
+error.dlq=log:dead?level=WARN

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -43,7 +43,7 @@ public class DerivativeConnector extends RouteBuilder {
     @Override
     public void configure() {
 
-        errorHandler(deadLetterChannel("broker:queue:ActiveMQ.DLQ"));
+        errorHandler(deadLetterChannel("{{error.dlq}}"));
 
         // Retry HTTP-related error conditions for longer (exponential backoff, delay)
         onException(HttpOperationFailedException.class)

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -65,7 +65,7 @@ public class DerivativeConnector extends RouteBuilder {
         onException(Exception.class)
             .maximumRedeliveries("{{error.maxRedeliveries}}")
             .log(
-                ERROR,
+                WARN,
                 LOGGER,
                 "Error connecting generating derivative with {{derivative.service.url}}: " +
                 "${exception.message}\n\n${exception.stacktrace}"

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -43,7 +43,7 @@ public class DerivativeConnector extends RouteBuilder {
     @Override
     public void configure() {
 
-        errorHandler(deadLetterChannel("{{error.dlq}}").disableRedelivery());
+        errorHandler(deadLetterChannel("{{error.dlq}}"));
 
         // Retry HTTP-related error conditions for longer (exponential backoff, delay)
         onException(HttpOperationFailedException.class)

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -51,9 +51,7 @@ public class DerivativeConnector extends RouteBuilder {
                 .redeliveryDelay("{{error.redeliveryDelay}}")
                 .backOffMultiplier("{{error.backoff}}")
                 .useExponentialBackOff()
-                .logRetryAttempted(true)
-                .retryAttemptedLogLevel(WARN)
-                .retriesExhaustedLogLevel(WARN)
+                .logRetryAttempted(false)
                 .useOriginalMessage()
                 .log(
                         WARN,

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -43,6 +43,8 @@ public class DerivativeConnector extends RouteBuilder {
     @Override
     public void configure() {
 
+        errorHandler(deadLetterChannel("broker:queue:ActiveMQ.DLQ"));
+
         // Retry HTTP-related error conditions for longer (exponential backoff, delay)
         onException(HttpOperationFailedException.class)
                 .maximumRedeliveries("{{error.maxRedeliveries}}")

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -43,7 +43,7 @@ public class DerivativeConnector extends RouteBuilder {
     @Override
     public void configure() {
 
-        errorHandler(deadLetterChannel("{{error.dlq}}"));
+        errorHandler(deadLetterChannel("{{error.dlq}}").disableRedelivery());
 
         // Retry HTTP-related error conditions for longer (exponential backoff, delay)
         onException(HttpOperationFailedException.class)

--- a/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-httpconfigurer-test.xml
+++ b/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-httpconfigurer-test.xml
@@ -11,6 +11,7 @@
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.derivative" update-strategy="reload" >
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="5"/>
+      <cm:property name="error.dlq" value="log:dead?level=WARN"/>
       <cm:property name="in.stream" value="seda:islandora-connector.derivative-index"/>
       <cm:property name="derivative.service.url" value="http://example.org/derivative/convert"/>
     </cm:default-properties>

--- a/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
+++ b/islandora-connector-derivative/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
@@ -13,6 +13,7 @@
       <cm:property name="error.maxRedeliveries" value="5"/>
       <cm:property name="error.redeliveryDelay" value="1000"/>
       <cm:property name="error.backoff" value="1.2"/>
+      <cm:property name="error.dlq" value="log:dead?level=WARN"/>
       <cm:property name="in.stream" value="seda:islandora-connector.derivative-index"/>
       <cm:property name="derivative.service.url" value="http://example.org/derivative/convert"/>
     </cm:default-properties>


### PR DESCRIPTION
Updates Alpaca with a dead letter queue endpoint, where undeliverable messages are sent.

Configuring the dead letter queue requires setting the `error.dlq` property.  By default, undeliverable messages will be logged.  In production, the intent is to set the `error.dlq` property to `broker:queue:ActiveMQ.DLQ` so that all undeliverable messages end up in the ActiveMQ dead letter queue, to be read off by the dead letter queue microservice.